### PR TITLE
Remove legacy `mode: 'jit'` config option

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,6 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
-    mode: 'jit',
     content: [
       "./app/**/*.tsx",
       "./app/**/*.jsx",


### PR DESCRIPTION
That's not needed anymore, since JIT is the default and only mode in Tailwind CSS v3 👍