### PR TITLE
Update 'Sign In' or 'Sign Up!' aux btn title

### DIFF
--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -37,7 +37,7 @@ function AuthForm({ isSignIn: isSignInProp = true, errors = {} }: PropsWithChild
 
                     <div className="text-right">
                         <small className="block">{ isSignIn ? `not a member?` : `already a member?` }</small>
-                        <button type="button"  title="Sign Up" onClick={() => { setIsSignIn(!isSignIn)}}>{ isSignIn ? `Sign Up!` : `Sign In` }</button>
+                        <button type="button"  title={ isSignIn ? `Sign Up!` : `Sign In` } onClick={() => { setIsSignIn(!isSignIn)}}>{ isSignIn ? `Sign Up!` : `Sign In` }</button>
                     </div>
                 </div>
             </fieldset>


### PR DESCRIPTION
Hello, one-aalam!

This is my first pull request ever, so forgive me for forgetting to branch my fork before pushing the changes to my own repo before opening this pull request.

It is a really simple change. I was looking If I could implement Zod or Yup library for form validation in your template (something I would like to learn how to implement) and saw that the title of the auxiliary button didn't change with the visible content of the button.

This pull request only applies to the title of this auxiliary button of the AuthForm that changes the form from a "Sing In" to a "Sign Up". It will only have an impact on accessibility and in some tooltips methods (not with Daisy UI).

Best Regards,

Lucas